### PR TITLE
Print the test results

### DIFF
--- a/sve_api/stress_tester.py
+++ b/sve_api/stress_tester.py
@@ -4,6 +4,13 @@ import os
 import subprocess
 import sys
 
+def strip_text(text):
+    passed_test_index = text.find("Passed test:")
+    if passed_test_index != -1:  # If "Passed test:" is found in the text
+        return text[passed_test_index:]
+    else:
+        return text
+        
 def invoke_test(env_vars, args):
     print(f"------------------- {env_vars} -------------------")
     # Prepare environment variables dictionary
@@ -20,7 +27,6 @@ def invoke_test(env_vars, args):
     try:
         # Run the command and capture output and errors
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-
         if 'fail' in result.stdout.lower():
             print("Test failed:")
             output_batch_lines = False
@@ -31,11 +37,19 @@ def invoke_test(env_vars, args):
                 if len(line.strip()) == 0:
                     output_batch_lines = False
                     print("..........................................")
-
+                
                 if output_batch_lines or ('System.Exception' in line) or ('at ' in line.strip()):
                     print(line)
-
-
+        else:
+            # Everything passed
+            test_count = 0
+            for line in result.stdout.splitlines():
+                if 'Beginning scenario:' in line:
+                    test_count = test_count+1
+                if 'Passed test:' in line:
+                    print(f'{strip_text(line)} : {test_count}')
+                    test_count = 0
+                    
         # Print the errors, if any
         if result.stderr:
             print("Errors:")

--- a/sve_api/stress_tester.py
+++ b/sve_api/stress_tester.py
@@ -100,6 +100,7 @@ if len(sys.argv) <= 1:
     exit(2)
 
 args = sys.argv[1:]
+print(f"Starting test: {' '.join(args)}")
 
 for mode in test_environments:
     print(f"===================Running {mode}===================")


### PR DESCRIPTION
I just wanted to print the test names and progress that people can paste. I could add `--verbose` flag or something to print this, but I think it will be good to print the overall results and copy/paste it on GH.

Sample output:

```
------------------- {'JitStress': '2', 'JitStressRegs': '0x2000'} -------------------
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Abs_float() : 16
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Abs_double() : 16
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Abs_sbyte() : 16
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Abs_short() : 16
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Abs_int() : 16
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Abs_long() : 16
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_float() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_double() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_sbyte() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_short() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_int() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_long() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_byte() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_ushort() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_uint() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_Add_ulong() : 19
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_float() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_double() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_sbyte() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_short() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_int() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_long() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_byte() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_ushort() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_uint() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.Sve_ConditionalSelect_ulong() : 7
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_float() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_double() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_sbyte() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_short() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_int() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_long() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_byte() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_ushort() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_uint() : 1
Passed test: _Sve_r::JIT.HardwareIntrinsics.Arm._Sve.Program.SveLoadVector_ulong() : 1
```